### PR TITLE
Add a parser for minimal Yara rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,11 @@
 name = "yaraio"
 version = "0.1.0"
 authors = ["Min Kim <msk@dolbo.net>"]
+build = "build.rs"
 
 [dependencies]
+lalrpop-util = "0.16"
+regex = "1"
+
+[build-dependencies]
+lalrpop = "0.16"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+extern crate lalrpop;
+
+fn main() {
+    lalrpop::process_root().unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,36 @@
+#[macro_use]
+extern crate lalrpop_util;
 
+lalrpop_mod!(pub yara);
+
+#[cfg(test)]
+mod tests {
+    use super::yara;
+
+    #[test]
+    fn empty() {
+        assert!(yara::RulesParser::new().parse("").is_ok());
+    }
+
+    #[test]
+    fn minimal_rule() {
+        assert!(
+            yara::RulesParser::new()
+                .parse("rule dummy { condition: true }")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn multiple_rules() {
+        let rules = yara::RulesParser::new()
+            .parse(
+                "
+rule r1 { condition: true }
+rule r2 { condition: false }
+rule r3 { condition: true }
+",
+            ).unwrap();
+        assert_eq!(rules.len(), 3);
+    }
+}

--- a/src/yara.lalrpop
+++ b/src/yara.lalrpop
@@ -1,0 +1,23 @@
+grammar;
+
+pub Rules: Vec<String> = {
+    => Vec::new(),
+    <rules:Rules> <r:Rule> => {
+        let mut rules = rules;
+        rules.push(r);
+        rules
+    },
+};
+
+Rule: String = "rule" <Identifier> "{" Condition "}" => <>.to_string();
+
+Condition: String = "condition" ":" <BooleanExpression> => <>;
+
+BooleanExpression: String = Expression => <>;
+
+Expression: String = {
+    "true" => "true".to_string(),
+    "false" => "false".to_string(),
+};
+
+Identifier: &'input str = r"[A-Za-z_][A-Za-z0-9_]*" => <>;


### PR DESCRIPTION
The first step toward a full Yara rule parser. The grammar file can
verify the simplest rule only. It needs to be extended to cover other
rules.

Resolves: #1